### PR TITLE
experiments with more precise option types. impressive sometimes but …

### DIFF
--- a/src/Option.ts
+++ b/src/Option.ts
@@ -7,6 +7,8 @@ import { WithEquality, areEqual, hasTrueEquality,
 import { toStringHelper } from "./SeqHelpers";
 import { contractTrueEquality} from "./Contract";
 
+// implementation also inspired by https://github.com/bcherny/tsoption
+
 /**
  * Expresses that a value may be present, or not.
  * @type T the item type
@@ -18,14 +20,15 @@ export abstract class Option<T> implements Value {
      * undefined gives a none
      * null gives a some
      */
-    static of<T>(v: T|undefined): Option<T> {
-        return (v === undefined) ? <None<T>>none : new Some(v);
-    }
+    static of: {
+            <T = {}>(value: undefined): None<T>;
+            <T>(value: T): Some<T>;
+    } = <any>(<T>(v:T|undefined) => (v === undefined) ? <None<T>>none : new Some(v));
 
     /**
      * The optional value expressing a missing value.
      */
-    static none<T>(): Option<T> {
+    static none<T>(): None<T> {
         return <None<T>>none;
     }
 
@@ -274,7 +277,7 @@ export class Some<T> extends Option<T> {
         return this.value;
     }
     
-    orElse(other: Option<T>): Option<T> {
+    orElse(other: Option<T>): Some<T> {
         return this;
     }
 
@@ -286,7 +289,7 @@ export class Some<T> extends Option<T> {
         return v === this.value;
     }
 
-    getOrUndefined(): T | undefined {
+    getOrUndefined(): T {
         return this.value;
     }
 
@@ -294,7 +297,7 @@ export class Some<T> extends Option<T> {
         return this.value;
     }
 
-    map<U>(fn: (v:T)=>U): Option<U> {
+    map<U>(fn: (v:T)=>U): Some<U> {
         return Option.of(fn(this.value));
     }
 
@@ -306,7 +309,7 @@ export class Some<T> extends Option<T> {
         return fn(this.value) ? this : Option.none<T>();
     }
 
-    ifPresent(fn:(v:T)=>void): Option<T> {
+    ifPresent(fn:(v:T)=>void): Some<T> {
         fn(this.value);
         return this;
     }
@@ -360,7 +363,7 @@ export class None<T> extends Option<T> {
         return true;
     }
 
-    orElse(other: Option<T>): Option<T> {
+    orElse<U extends Option<T>>(other: U): U {
         return other;
     }
 
@@ -380,7 +383,7 @@ export class None<T> extends Option<T> {
         return alt;
     }
 
-    map<U>(fn: (v:T)=>U): Option<U> {
+    map<U>(fn: (v:T)=>U): None<U> {
         return <None<U>>none;
     }
 
@@ -388,11 +391,11 @@ export class None<T> extends Option<T> {
         return <None<U>>none;
     }
 
-    filter(fn: (v:T)=>boolean): Option<T> {
+    filter(fn: (v:T)=>boolean): None<T> {
         return <None<T>>none;
     }
 
-    ifPresent(fn:(v:T)=>void): Option<T> {
+    ifPresent(fn:(v:T)=>void): None<T> {
         return this;
     }
 

--- a/tests/Option.ts
+++ b/tests/Option.ts
@@ -34,7 +34,7 @@ describe("option comparison", () => {
     it("should fail compilation on an obviously bad equality test", () =>
        assertFailCompile(
            "Option.of([1]).equals(Option.of([1]))", "Argument of type \'" +
-               "Option<number[]>\' is not assignable to parameter"));
+               "Some<number[]>\' is not assignable to parameter"));
     it("should fail compilation on an obviously bad contains test", () =>
        assertFailCompile(
            "Option.of([1]).contains([1])",
@@ -86,7 +86,7 @@ describe("Option helpers", () => {
     it("should fail sequence when some are none", () =>
        assert.ok(
            Option.none().equals(
-               Option.sequence(Vector.of(Option.of(1), Option.none(), Option.of(3))))));
+               Option.sequence(Vector.of<Option<number>>(Option.of(1), Option.none(), Option.of(3))))));
     it("should liftA2", () => assert.ok(Option.of(11).equals(
         Option.liftA2((x:number,y:number) => x+y)(Option.of(5), Option.of(6)))));
     it("should abort liftA2 on none", () => assert.ok(Option.none().equals(
@@ -122,4 +122,10 @@ describe("option retrieval", () => {
             assert.equal(5, opt.get());
         }
     });
+    it("should know whether we got a Some from Option.of", () =>
+       assert.equal(5, Option.of(5).get()));
+    it("should know whether we got a Some from None.orElse", () =>
+       assert.equal(5, Option.none<number>().orElse(Option.of(5)).get()));
+    it("should know whether we got a Some from Some.orElse", () =>
+       assert.equal(5, Option.of(5).orElse(Option.none<number>()).get()));
 });


### PR DESCRIPTION
…two gotchas mean i don't want it in master for now:

let x: number|undefined;
const y = Option.of(x);

=> Inferred to Some<number|undefined> <-- i never want that type!

Need Option.from<number>(x) to make it work.

another one:

List.of(Option.of(5), Option.none<number>())

doesn't compile anymore. It says None<number> is not compatible with Some<number>.

Need List.of<Option<number>> to make it work.

Also generally speaking I'm not sure it brings much apart from simple demos
(and making super nice apidocs) -- in the real world you don't deal with Some
and None much -- pretty quickly it's all Option anyway.