### PR TITLE
add the 'do notation' function to Future

### DIFF
--- a/src/Future.ts
+++ b/src/Future.ts
@@ -67,6 +67,15 @@ export class Future<T> {
     }
 
     /**
+     * Creates a Future from a do-notation block. asyncc/await can use
+     * inside the block, the result value will be wrapped into a new Future,
+     * without be worry about add try/catch to the async/await code.
+     */
+    static do<T>(doNotationBlock: ()=>Promise<T>): Future<T> {
+        return Future.of(doNotationBlock())
+    }
+
+    /**
      * The `then` call is not meant to be a part of the `Future` API,
      * we need then so that `await` works directly.
      * This method is eager, will trigger the underlying Promise.

--- a/tests/Future.ts
+++ b/tests/Future.ts
@@ -284,3 +284,38 @@ describe("Future.on*", () => {
         assert.ok(Either.left(5).equals(v));
     });
 });
+
+describe("Future do notation*", () => {
+    it("do notation creates a successful future", async () => {
+        const f1 = Future.ok(1)
+        const f2 = Future.ok(2)
+      
+        const f3 = Future.do(async () => {
+            const v1 = await f1
+            const v2 = await f2
+            return v1 + v2
+        })
+      
+        const v3 = await f3
+        assert.deepEqual(3, v3);
+    });
+
+    it("do notation creates a failable future", async () => {
+        const f1 = Future.ok(1)
+        const f2 = Future.failed<number>("bad number")
+        
+        const f3 = Future.do(async () => {
+            const v1 = await f1
+            const v2 = await f2
+            return v1 + v2
+        })
+
+        try {
+          const v3 = await f3
+          assert.fail("Error: Future must fail")
+
+        } catch (error) {
+          assert.deepEqual(error, "bad number");
+        }
+    });
+});


### PR DESCRIPTION
Added a "do notation" function in order to use async/await without caring to add try/catch blocks