### PR TITLE
Future rework

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prelude.ts",
-    "version": "0.7.7",
+    "version": "0.7.8",
     "description": "A typescript functional programming library",
     "main": "dist/src/index.js",
     "typings": "dist/src/index.d.ts",

--- a/src/Future.ts
+++ b/src/Future.ts
@@ -159,7 +159,7 @@ export class Future<T> {
             .map(
                 f => f
                     .map<FutOptPair>(item => [f, Option.of(item)])
-                    .orElse(Future.ok<FutOptPair>([f, Option.none<T>()])));
+                    .recoverWith(_=>Future.ok<FutOptPair>([f, Option.none<T>()])));
         // go for the first completed of the iterable
         // remember after our map they're all successful now
         const success = Future.firstCompletedOf(velts);
@@ -303,10 +303,12 @@ export class Future<T> {
     
     /**
      * Has no effect if this Future is successful. If it's failed however,
-     * a Future equivalent to the one given as parameter is returned.
+     * the function you give will be called, receiving as parameter
+     * the error contents, and a Future equivalent to the one your
+     * function returns will be returned.
      */
-    orElse(other: Future<T>): Future<T> {
-        return new Future<T>(this.promise.catch(_ => other.promise));
+    recoverWith(f: (err:any)=>Future<T>): Future<T> {
+        return new Future<T>(this.promise.catch(err => f(err).promise));
     }
 
     /**

--- a/src/Future.ts
+++ b/src/Future.ts
@@ -22,15 +22,15 @@ export class Future<T> {
     private constructor(private promise: Promise<T[]>) { }
 
     /**
-     * Build a Future from callback-style call.
-     * You get one callback to signal success, throw to signal
-     * failure.
+     * Build a Future in the same way as the 'new Promise'
+     * constructor.
+     * You get one callback to signal success (resolve),
+     * failure (reject), or you can throw to signal failure.
      *
-     *     Future.ofCallbackApi<string>(done => setTimeout(done, 10, "hello!"))
+     *     Future.ofPromiseCtor<string>((resolve,reject) => setTimeout(resolve, 10, "hello!"))
      */
-    static ofCallbackApi<T>(cb: (done:(x:T)=>void)=>void): Future<T> {
-        return new Future(new Promise<T[]>(
-            (resolve,reject) => cb((v:T) => resolve([v]))));
+    static ofPromiseCtor<T>(executor: (resolve:(x:T)=>void, reject: (x:any)=>void)=>void): Future<T> {
+        return new Future(new Promise(executor).then(v=>[v]));
     }
 
     /**

--- a/src/Future.ts
+++ b/src/Future.ts
@@ -41,6 +41,21 @@ export class Future<T> {
     }
 
     /**
+     * Build a Future from a node-style callback API, for instance:
+     *
+     *     Future.ofCallback<string>(cb => fs.readFile('/etc/passwd', 'utf-8', cb))
+     */
+    static ofCallback<T>(fn: (cb:(err:any, val:T)=>void)=>void): Future<T> {
+        return Future.ofPromiseCtor((resolve,reject)=>fn((err, data)=>{
+            if (err) {
+                reject(err);
+            } else {
+                resolve(data);
+            }
+        }));
+    }
+
+    /**
      * Build a successful Future with the value you provide.
      */
     static ok<T>(val:T): Future<T> {

--- a/src/Future.ts
+++ b/src/Future.ts
@@ -70,12 +70,19 @@ export class Future<T> {
     }
 
     /**
-     * Creates a Future from a do-notation block. asyncc/await can use
-     * inside the block, the result value will be wrapped into a new Future,
-     * without be worry about add try/catch to the async/await code.
+     * Creates a Future from a function returning a Promise,
+     * which can be inline in the call, for instance:
+     *
+     *     const f1 = Future.ok(1);
+     *     const f2 = Future.ok(2);
+     *     return Future.do(async () => {
+     *         const v1 = await f1;
+     *         const v2 = await f2;
+     *         return v1 + v2;
+     *     });
      */
-    static do<T>(doNotationBlock: ()=>Promise<T>): Future<T> {
-        return Future.of(doNotationBlock())
+    static do<T>(fn: ()=>Promise<T>): Future<T> {
+        return Future.of(fn())
     }
 
     /**

--- a/tests/Comments.ts
+++ b/tests/Comments.ts
@@ -165,6 +165,7 @@ function generateTestFileContents(fname: string, samplesInfo: Vector<SampleInfo>
         import { Option, Some, None } from "../src/Option";
         import { instanceOf, typeOf } from "../src/Comparison";
         import * as assert from 'assert';
+        import * as fs from 'fs';
 
         function myEq(a:any, b:any): boolean {
              if (a === null && b === null) {

--- a/tests/Future.ts
+++ b/tests/Future.ts
@@ -1,6 +1,8 @@
 import { Future } from "../src/Future";
+import { Vector } from "../src/Vector";
 import { Option } from "../src/Option";
 import { Either } from "../src/Either";
+import * as fs from 'fs';
 import * as assert from 'assert';
 
 async function ensureFailedWithValue<T>(val: any, promise:Promise<T>) {
@@ -21,6 +23,25 @@ describe("Future.of", () => {
         // shows the need for future.catch!?
         // await Future.of(new Promise((a,r) => r(5)))
         return ensureFailedWithValue(5, Future.of(Promise.reject(5)).toPromise());
+    });
+});
+describe("Future.ofCallback (these tests will fail on windows)", () => {
+    it("properly operates with fs.readFile", async () => {
+        const passwd = await Future.ofCallback<string>(
+            cb => fs.readFile("/etc/passwd", "utf-8", cb));
+        // the first line of /etc/passwd should contain 6 ':' characters
+        assert.equal(6, Vector.ofIterable(passwd.split("\n")[0])
+                     .filter(c => c===':').length());
+    });
+    it("properly operates with fs.readFile in case of errors", async () => {
+        try {
+            const passwd = await Future.ofCallback<string>(
+                cb => fs.readFile("/efdtc/pasdsswd", "utf-8", cb));
+            assert.ok(false); // should not make it here
+        } catch (err) {
+            // file does not exist
+            assert.equal('ENOENT', err.code);
+        }
     });
 });
 describe("Future basics", () => {

--- a/tests/Future.ts
+++ b/tests/Future.ts
@@ -231,10 +231,14 @@ describe("Future.on*", () => {
     });
     it("doesn't calls onSuccess when it shouldn't", async () => {
         let v = 0;
+        let failed = false;
         try {
             await Future.failed<number>(5)
                 .onSuccess(x => v = x);
-        } catch { }
+        } catch {
+            failed = true;
+        }
+        assert.ok(failed);
         assert.deepEqual(0, v);
     });
     it("doesn't call onFailure when it shouldn't", async () => {
@@ -245,10 +249,14 @@ describe("Future.on*", () => {
     });
     it("calls onFailure when it should", async () => {
         let v = 0;
+        let failed = false;
         try {
             await Future.failed(5)
                 .onFailure(x => v = x);
-        } catch { }
+        } catch {
+            failed = true;
+        }
+        assert.ok(failed);
         assert.deepEqual(5, v);
     });
     it("calls onComplete on success", async () => {

--- a/tests/Future.ts
+++ b/tests/Future.ts
@@ -24,11 +24,6 @@ describe("Future.of", () => {
     });
 });
 describe("Future basics", () => {
-    it("is lazy", () => {
-        let i=0;
-        Future.ofCallbackApi<number>(done=>{++i; done(i)});
-        assert.deepEqual(0, i);
-    });
     it("works when triggered", async () => {
         let i=0;
         await Future.ofCallbackApi(done=>done(++i));
@@ -66,13 +61,6 @@ describe("Future basics", () => {
         await f;
         assert.deepEqual(1, i);
         await f;
-        assert.deepEqual(1, i);
-    });
-    it("is async also when triggered", async () => {
-        let i=0;
-        const f = Future.ofCallbackApi(done=>setTimeout(done, 20, ++i));
-        assert.deepEqual(0, i);
-        assert.deepEqual(1, await f);
         assert.deepEqual(1, i);
     });
 });
@@ -191,12 +179,6 @@ describe("Future.filter", () => {
     });
 });
 describe("Future.orElse", () => {
-    it("is lazy", () => {
-        let called = false;
-        Future.ofCallbackApi(done => {called=true; done(2)})
-            .orElse(Future.ofCallbackApi(done => { called=true; done(3)}));
-        assert.deepEqual(false, called);
-    });
     it("is a nop if the first promise succeeds, even if it's slower", async () => {
         assert.deepEqual(1, await Future.ofCallbackApi(done => setTimeout(done, 50, 1))
                      .orElse(Future.ok(2)));

--- a/tests/Future.ts
+++ b/tests/Future.ts
@@ -25,18 +25,17 @@ describe("Future.of", () => {
         return ensureFailedWithValue(5, Future.of(Promise.reject(5)).toPromise());
     });
 });
-describe("Future.ofCallback (these tests will fail on windows)", () => {
+describe("Future.ofCallback", () => {
     it("properly operates with fs.readFile", async () => {
-        const passwd = await Future.ofCallback<string>(
-            cb => fs.readFile("/etc/passwd", "utf-8", cb));
-        // the first line of /etc/passwd should contain 6 ':' characters
-        assert.equal(6, Vector.ofIterable(passwd.split("\n")[0])
-                     .filter(c => c===':').length());
+        const readme = await Future.ofCallback<string>(
+            cb => fs.readFile(__dirname + "/../../README.md", "utf-8", cb));
+        // the readme should be long at least 1000 bytes
+        assert.ok(readme.length > 1000);
     });
     it("properly operates with fs.readFile in case of errors", async () => {
         try {
             const passwd = await Future.ofCallback<string>(
-                cb => fs.readFile("/efdtc/pasdsswd", "utf-8", cb));
+                cb => fs.readFile(__dirname + "/../../README.mddd", "utf-8", cb));
             assert.ok(false); // should not make it here
         } catch (err) {
             // file does not exist
@@ -326,7 +325,7 @@ describe("Future do notation*", () => {
         assert.deepEqual(3, v3);
     });
 
-    it("do notation creates a failable future", async () => {
+    it("do notation creates a failed future", async () => {
         const f1 = Future.ok(1)
         const f2 = Future.failed<number>("bad number")
         

--- a/tests/Future.ts
+++ b/tests/Future.ts
@@ -178,13 +178,19 @@ describe("Future.filter", () => {
             "value was 1", Future.ok(1).filter(x => x >= 2, v => "value was " + v).toPromise());
     });
 });
-describe("Future.orElse", () => {
+describe("Future.recoverWith", () => {
     it("is a nop if the first promise succeeds, even if it's slower", async () => {
         assert.deepEqual(1, await Future.ofCallbackApi(done => setTimeout(done, 50, 1))
-                     .orElse(Future.ok(2)));
+                         .recoverWith(_=>Future.ok(2)));
     });
     it("falls back to the second promise in case the first one fails", async () => {
-        assert.deepEqual(2, await Future.failed("oops").orElse(Future.ok(2)));
+        assert.deepEqual("oops", await Future.failed("oops").recoverWith(Future.ok));
+    });
+    it("falls back to the second promise in case both fail", async () => {
+        return ensureFailedWithValue(
+            "still not",
+            Future.failed("oops")
+                .recoverWith(_ => Future.failed("still not")).toPromise());
     });
 });
 describe("Future.find", () => {


### PR DESCRIPTION
this is the PR that I promised in pr #8.
it changes the Future api in a number of ways and of course that would mean a new major version of prelude. On top of that I have a few other Future improvements in mind, but that's the core of the changes (what I have in mind besides this are additions not changes).

@Rpallas92, @qm3ster if you have any feedback let me know (now or in the future of course, including after I merge this PR).

Here is a summary of the changes:

1. Future is now eager (autostarts when created, like Promise)
2. Add the Future.do call (merge PR from @RPallas92, change his apidoc)
3. Improve/fix Future.onFailure, onComplete and onSuccess: the old implementation was returning new Futures, now we return 'this'. The old implementation was incorrect, this is an API change so I'm bringing it up in this PR too
4. modify ofCallbackApi to take the same parameters as 'new Promise', and rename it to 'ofPromiseCtor' (thanks @qm3ster for the suggestion)
5. add Future.ofCallback (thanks @qm3ster for the suggestion) -- node-style callbacks. Maybe could still rename to ofNodeCallback?

It's quite something but in the end porting code using the current implementation of Futures shouldn't be that bad. Any feedback on these changes (naming, implementations,...) is welcome. I might merge this PR quite fast, maybe before you have time to review it, if that's the case feel free to open an issue to discuss the changes, even after the merge.