### PR TITLE
Add Optics DSL

### DIFF
--- a/src/Optics.ts
+++ b/src/Optics.ts
@@ -2,27 +2,41 @@
 import { Option, Some, None } from "./Option";
 
 export const optics = <T>(value: T): Optic<T> => {
-  return new Optic(value);
+	return new Optic(value);
 };
 
 export class Optic<T> {
-	private value: Option<T>;
-	
-  constructor(value: T) {
-    this.value = Option.of(value);
+	readonly value: Option<T>;
+
+	constructor(value: T) {
+		this.value = Option.of(value);
+		this.index = this.indexFunc as any;
 	}
 
-  public prop<K extends keyof T>(key: K): Optic<NonNullable<T[K]>> {
+	public prop<K extends keyof T>(key: K): Optic<NonNullable<T[K]>> {
 		const property = this.value.map(value => value[key]);
 
 		if (property.isNone()) {
 			return new Optic(undefined) as any;
-		} 
-		return new Optic(property.get()) as any;
-  }
+		}
+		return new Optic(property.get()) as Optic<NonNullable<T[K]>>;
+	}
 
-  public get(): Option<T> {
-    return this.value;
-  }
+	public index: T extends Array<infer I>
+		? (index: number) => Optic<I>
+		: Optic<undefined>
+
+	private indexFunc<I>(index: number): Optic<I> {
+		const indexValue = this.value.map((value: any) => value[index]) as Option<I>;
+		if (indexValue.isNone()) {
+			return new Optic(undefined as any);
+		}
+		return new Optic(indexValue.get());
+	};
+
+	public get(): Option<T> {
+		return this.value;
+	}
 
 }
+

--- a/src/Optics.ts
+++ b/src/Optics.ts
@@ -21,19 +21,8 @@ export class Optic<T> {
 		return new Optic(property.get()) as any;
   }
 
-  /*public index: T extends Array<infer I> // tslint:disable-line
-    ? (index: number) => Optic<I>
-    : Optic<undefined>;*/
-
   public get(): Option<T> {
     return this.value;
   }
 
 }
-
-/*Optic.prototype.index = function<U>(index: number): Optic<U> {
-  if (this.value[index] === undefined) {
-    return new Optic(undefined as any);
-  }
-  return new Optic(this.value[index]);
-};*/

--- a/src/Optics.ts
+++ b/src/Optics.ts
@@ -1,0 +1,39 @@
+
+import { Option, Some, None } from "./Option";
+
+export const optics = <T>(value: T): Optic<T> => {
+  return new Optic(value);
+};
+
+export class Optic<T> {
+	private value: Option<T>;
+	
+  constructor(value: T) {
+    this.value = Option.of(value);
+	}
+
+  public prop<K extends keyof T>(key: K): Optic<NonNullable<T[K]>> {
+		const property = this.value.map(value => value[key]);
+
+		if (property.isNone()) {
+			return new Optic(undefined) as any;
+		} 
+		return new Optic(property.get()) as any;
+  }
+
+  /*public index: T extends Array<infer I> // tslint:disable-line
+    ? (index: number) => Optic<I>
+    : Optic<undefined>;*/
+
+  public get(): Option<T> {
+    return this.value;
+  }
+
+}
+
+/*Optic.prototype.index = function<U>(index: number): Optic<U> {
+  if (this.value[index] === undefined) {
+    return new Optic(undefined as any);
+  }
+  return new Optic(this.value[index]);
+};*/

--- a/tests/Optics.ts
+++ b/tests/Optics.ts
@@ -6,6 +6,7 @@ import * as assert from 'assert'
 interface Person {
 	name: string
 	address?: Address
+	phoneNumbers?: number[]
 }
 
 interface Address {
@@ -23,7 +24,8 @@ const emmanuel: Person = {
 	address: {
 		city: "Maribor",
 		street: "Fake Street"
-	}
+	},
+	phoneNumbers: [123451, 134561, 124567]
 }
 
 const opticsRicardo = optics(ricardo)
@@ -48,6 +50,29 @@ describe("Optics can get props", () => {
 
 	it("should return Some with the actual value when getting existing property", () => {
 		assert( opticsEmmanuel.prop("address").prop("city").get().getOrNull() === "Maribor")
+	})
+});
+
+
+describe("Optics can access arrays", () => {
+	it("should return Option when getting existing index value", () => {
+		assert(opticsEmmanuel.prop("phoneNumbers").index(0) instanceof Optic)
+	})
+
+	it("should return Option when getting an out of bounds index value ", () => {
+		assert(opticsEmmanuel.prop("phoneNumbers").index(1000) instanceof Optic)
+	})
+
+	it("should return Some when getting existing index value", () => {
+		assert(opticsEmmanuel.prop("phoneNumbers").index(1).get().isSome())
+	})
+
+	it("should return None when getting an out of bounds index value ", () => {
+		assert(opticsEmmanuel.prop("phoneNumbers").index(4).get().isNone())
+	})
+
+	it("should return Some with the actual value when getting existing index value", () => {
+		assert(opticsEmmanuel.prop("phoneNumbers").index(2).get().getOrNull() === 124567)
 	})
 });
 

--- a/tests/Optics.ts
+++ b/tests/Optics.ts
@@ -1,0 +1,53 @@
+// import { Option, Some, None } from "../src/Option";
+import { optics, Optic } from "../src/Optics";
+
+import * as assert from 'assert'
+
+interface Person {
+	name: string
+	address?: Address
+}
+
+interface Address {
+	city: string
+	street: string
+	number?: number
+}
+
+const ricardo: Person = {
+	name: "Ricardo"
+}
+
+const emmanuel: Person = {
+	name: "Emmanuel",
+	address: {
+		city: "Maribor",
+		street: "Fake Street"
+	}
+}
+
+const opticsRicardo = optics(ricardo)
+const opticsEmmanuel = optics(emmanuel)
+
+describe("Optics can get props", () => {
+	it("should return Option when getting existing property", () => {
+		assert(opticsRicardo.prop("name") instanceof Optic)
+	})
+
+	it("should return Option when getting undefined property ", () => {
+		assert(opticsRicardo.prop("address") instanceof Optic)
+	})
+
+	it("should return Some when getting existing property", () => {
+		assert(opticsRicardo.prop("name").get().isSome())
+	})
+
+	it("should return None when getting existing property", () => {
+		assert(opticsRicardo.prop("address").get().isNone())
+	})
+
+	it("should return Some with the actual value when getting existing property", () => {
+		assert( opticsEmmanuel.prop("address").prop("city").get().getOrNull() === "Maribor")
+	})
+});
+


### PR DESCRIPTION
Following the library's philosophy of simplicity, I have added a Optics DSL without the overhead that is type-safe and easy to use.

Please check tests/Optics.ts to see how it works.

I will add a `set` function that returns a new object with the property modified.

Does this PR make sense? @emmanueltouzery 